### PR TITLE
fix: resolve race condition in MetricsServer startup logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,8 @@ async function initializeMetricsServer(): Promise<void> {
   if (config.METRICS_ENABLED === 'true') {
     try {
       await metricsServer.start();
-      Logger.info(`Metrics server started on port ${config.METRICS_PORT}`);
+      const actualPort = metricsServer.getPort();
+      Logger.info(`Metrics server started on port ${actualPort || config.METRICS_PORT}`);
     } catch (error) {
       Logger.warn('Failed to start metrics server, continuing without metrics endpoint', error);
     }

--- a/src/utils/metrics_server.ts
+++ b/src/utils/metrics_server.ts
@@ -102,6 +102,23 @@ export class MetricsServer {
   }
 
   /**
+   * Get the actual port the server is listening on
+   * This is useful when port is set to 0 (dynamic port allocation)
+   */
+  getPort(): number | null {
+    if (!this.server || !this.server.listening) {
+      return null;
+    }
+    
+    const address = this.server.address();
+    if (address && typeof address === 'object' && 'port' in address) {
+      return address.port;
+    }
+    
+    return null;
+  }
+
+  /**
    * Handle HTTP requests
    */
   private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {


### PR DESCRIPTION
This PR fixes the race condition where `src/index.ts` logs `config.METRICS_PORT` instead of the actual listening port when using dynamic port allocation (METRICS_PORT=0).

## Changes
- Added `getPort() method to MetricsServer class to retrieve actual listening port
- Updated startup logging to use actual port instead of configured port
- Handles dynamic port allocation properly when METRICS_PORT=0

Resolves #32

🤖 Generated with [Claude Code](https://claude.ai/code)