### PR TITLE
Security: bind MetricsServer to 127.0.0.1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Enable metrics by setting environment variables:
 ```bash
 METRICS_ENABLED=true        # Enable metrics server (default: true)
 METRICS_PORT=9090          # Metrics server port (default: 9090)
-METRICS_HOST=0.0.0.0       # Metrics server host (default: 0.0.0.0)
+METRICS_HOST=127.0.0.1     # Metrics server host (default: 127.0.0.1, use 0.0.0.0 to bind to all interfaces)
 ```
 
 ### Usage Examples

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -117,7 +117,7 @@ export const config = {
   // Metrics server configuration
   METRICS_ENABLED: process.env.METRICS_ENABLED || 'true',
   METRICS_PORT: validatePort(process.env.METRICS_PORT || '9090').toString(),
-  METRICS_HOST: process.env.METRICS_HOST || '0.0.0.0',
+  METRICS_HOST: process.env.METRICS_HOST || '127.0.0.1',
 };
 
 /**

--- a/src/utils/metrics_server.ts
+++ b/src/utils/metrics_server.ts
@@ -30,7 +30,7 @@ export class MetricsServer {
   constructor(config?: Partial<MetricsServerConfig>) {
     this.config = {
       port: parseInt(process.env.METRICS_PORT || config?.port?.toString() || '9090', 10),
-      host: process.env.METRICS_HOST || config?.host || '0.0.0.0',
+      host: process.env.METRICS_HOST || config?.host || '127.0.0.1',
       enabled: process.env.METRICS_ENABLED === 'true' || config?.enabled === true,
     };
 


### PR DESCRIPTION
Change default METRICS_HOST from 0.0.0.0 to 127.0.0.1 to improve security by binding to localhost only. Environment variable override still works to allow public exposure when explicitly configured.

Fixes #41

Generated with [Claude Code](https://claude.ai/code)