### PR TITLE
feat: add rate limiting to /metrics endpoint

### DIFF
--- a/src/utils/__tests__/metrics_server.test.ts
+++ b/src/utils/__tests__/metrics_server.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, jest, beforeEach, afterEach, beforeAll, afterAll } from '@jest/globals';
+import http from 'http';
+
+// Save original environment to restore it later
+const originalEnv = process.env;
+
+// Mock dependencies before importing the main module
+jest.mock('../logger', () => ({
+  Logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+  },
+}));
+
+jest.mock('../metrics_collector', () => ({
+  metricsCollector: {
+    formatJsonMetrics: jest.fn().mockReturnValue('{"mock": "json"}'),
+    formatPrometheusMetrics: jest.fn().mockReturnValue('# Mock prometheus metrics'),
+    getSummary: jest.fn().mockReturnValue({ requests: 0, errors: 0 }),
+  },
+}));
+
+jest.mock('../config', () => ({
+  config: {
+    enableMetrics: true,
+  },
+}));
+
+// Import after mocking
+import { MetricsServer } from '../metrics_server.js';
+
+describe('MetricsServer', () => {
+  let metricsServer: MetricsServer;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (metricsServer && metricsServer.isRunning()) {
+      await metricsServer.stop();
+    }
+    process.env = originalEnv;
+  });
+
+  describe('Rate Limiting Configuration', () => {
+    it('should use default rate limit of 60 requests per minute', () => {
+      delete process.env.METRICS_RATE_LIMIT;
+      metricsServer = new MetricsServer();
+      const config = metricsServer.getConfig();
+      expect(config.rateLimit).toBe(60);
+    });
+
+    it('should use METRICS_RATE_LIMIT environment variable', () => {
+      process.env.METRICS_RATE_LIMIT = '120';
+      metricsServer = new MetricsServer();
+      const config = metricsServer.getConfig();
+      expect(config.rateLimit).toBe(120);
+    });
+
+    it('should use config parameter for rate limit', () => {
+      metricsServer = new MetricsServer({ rateLimit: 30 });
+      const config = metricsServer.getConfig();
+      expect(config.rateLimit).toBe(30);
+    });
+
+    it('should prioritize environment variable over config parameter', () => {
+      process.env.METRICS_RATE_LIMIT = '90';
+      metricsServer = new MetricsServer({ rateLimit: 30 });
+      const config = metricsServer.getConfig();
+      expect(config.rateLimit).toBe(90);
+    });
+  });
+
+  describe('Rate Limiting Functionality', () => {
+    beforeEach(async () => {
+      process.env.METRICS_ENABLED = 'true';
+      process.env.METRICS_RATE_LIMIT = '2'; // Set low limit for testing
+      metricsServer = new MetricsServer({
+        port: 0, // Use dynamic port
+        enabled: true,
+      });
+      await metricsServer.start();
+    });
+
+    afterEach(async () => {
+      if (metricsServer && metricsServer.isRunning()) {
+        await metricsServer.stop();
+      }
+    });
+
+    it('should allow requests within rate limit', async () => {
+      const port = metricsServer.getPort();
+      expect(port).not.toBeNull();
+
+      // First request should succeed
+      const response1 = await makeRequest(port!, '/metrics');
+      expect(response1.statusCode).toBe(200);
+      expect(response1.headers['x-ratelimit-limit']).toBe('2');
+      expect(response1.headers['x-ratelimit-remaining']).toBe('1');
+
+      // Second request should succeed
+      const response2 = await makeRequest(port!, '/metrics');
+      expect(response2.statusCode).toBe(200);
+      expect(response2.headers['x-ratelimit-remaining']).toBe('0');
+    });
+
+    it('should block requests exceeding rate limit with HTTP 429', async () => {
+      const port = metricsServer.getPort();
+      expect(port).not.toBeNull();
+
+      // Make two requests to reach the limit
+      await makeRequest(port!, '/metrics');
+      await makeRequest(port!, '/metrics');
+
+      // Third request should be blocked
+      const response = await makeRequest(port!, '/metrics');
+      expect(response.statusCode).toBe(429);
+      expect(response.headers['x-ratelimit-limit']).toBe('2');
+      expect(response.headers['x-ratelimit-remaining']).toBe('0');
+      expect(response.headers['retry-after']).toBeDefined();
+      
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('Too Many Requests');
+      expect(body.statusCode).toBe(429);
+    });
+
+    it('should include proper rate limit headers', async () => {
+      const port = metricsServer.getPort();
+      expect(port).not.toBeNull();
+
+      const response = await makeRequest(port!, '/metrics');
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['x-ratelimit-limit']).toBe('2');
+      expect(response.headers['x-ratelimit-remaining']).toBe('1');
+      expect(response.headers['x-ratelimit-reset']).toBeDefined();
+      
+      // Parse the reset timestamp and verify it's in the future
+      const resetTime = parseInt(response.headers['x-ratelimit-reset'] as string);
+      expect(resetTime).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    });
+
+    it('should reset rate limit after time window', async () => {
+      const port = metricsServer.getPort();
+      expect(port).not.toBeNull();
+
+      // Make requests to reach the limit
+      await makeRequest(port!, '/metrics');
+      await makeRequest(port!, '/metrics');
+
+      // Third request should be blocked
+      const blockedResponse = await makeRequest(port!, '/metrics');
+      expect(blockedResponse.statusCode).toBe(429);
+
+      // Wait for rate limit window to reset (1 minute + small buffer)
+      // For testing, we'll mock the time passage
+      jest.useFakeTimers();
+      jest.advanceTimersByTime(61 * 1000); // Advance by 61 seconds
+
+      // New request should succeed after window reset
+      const response = await makeRequest(port!, '/metrics');
+      expect(response.statusCode).toBe(200);
+      
+      jest.useRealTimers();
+    }, 10000);
+
+    it('should handle different IP addresses separately', async () => {
+      const port = metricsServer.getPort();
+      expect(port).not.toBeNull();
+
+      // Simulate requests from different IPs by setting X-Forwarded-For header
+      const response1 = await makeRequest(port!, '/metrics', { 'X-Forwarded-For': '192.168.1.1' });
+      expect(response1.statusCode).toBe(200);
+      expect(response1.headers['x-ratelimit-remaining']).toBe('1');
+
+      const response2 = await makeRequest(port!, '/metrics', { 'X-Forwarded-For': '192.168.1.2' });
+      expect(response2.statusCode).toBe(200);
+      expect(response2.headers['x-ratelimit-remaining']).toBe('1');
+    });
+
+    it('should not apply rate limiting to non-metrics endpoints', async () => {
+      const port = metricsServer.getPort();
+      expect(port).not.toBeNull();
+
+      // Make requests to reach the limit on /metrics
+      await makeRequest(port!, '/metrics');
+      await makeRequest(port!, '/metrics');
+
+      // Request to /health should still work
+      const response = await makeRequest(port!, '/health');
+      expect(response.statusCode).toBe(200);
+    });
+  });
+
+  describe('Client IP Detection', () => {
+    beforeEach(async () => {
+      process.env.METRICS_ENABLED = 'true';
+      metricsServer = new MetricsServer({
+        port: 0,
+        enabled: true,
+      });
+      await metricsServer.start();
+    });
+
+    it('should extract IP from X-Forwarded-For header', async () => {
+      const port = metricsServer.getPort();
+      expect(port).not.toBeNull();
+
+      const response = await makeRequest(port!, '/metrics', { 
+        'X-Forwarded-For': '203.0.113.1, 192.168.1.1, 10.0.0.1' 
+      });
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should extract IP from X-Real-IP header', async () => {
+      const port = metricsServer.getPort();
+      expect(port).not.toBeNull();
+
+      const response = await makeRequest(port!, '/metrics', { 
+        'X-Real-IP': '203.0.113.2' 
+      });
+      expect(response.statusCode).toBe(200);
+    });
+  });
+});
+
+/**
+ * Helper function to make HTTP requests for testing
+ */
+function makeRequest(
+  port: number, 
+  path: string, 
+  headers: Record<string, string> = {}
+): Promise<{
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: '127.0.0.1',
+      port,
+      path,
+      method: 'GET',
+      headers,
+    };
+
+    const req = http.request(options, (res) => {
+      let body = '';
+      res.on('data', (chunk) => {
+        body += chunk;
+      });
+
+      res.on('end', () => {
+        resolve({
+          statusCode: res.statusCode || 0,
+          headers: res.headers as Record<string, string>,
+          body,
+        });
+      });
+    });
+
+    req.on('error', reject);
+    req.end();
+  });
+}

--- a/src/utils/__tests__/metrics_server_rate_limit.test.ts
+++ b/src/utils/__tests__/metrics_server_rate_limit.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+// Mock the logger to prevent setup issues
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  log: jest.fn(),
+};
+
+// Mock metricsCollector
+const mockMetricsCollector = {
+  formatJsonMetrics: jest.fn().mockReturnValue('{"test": "metrics"}'),
+  formatPrometheusMetrics: jest.fn().mockReturnValue('# Test metrics\ntest_metric 1'),
+  getSummary: jest.fn().mockReturnValue({ requests: 0, errors: 0 }),
+};
+
+// Mock config
+const mockConfig = {
+  enableMetrics: true,
+};
+
+// Use dynamic imports to avoid the jest module resolution issues
+describe('MetricsServer Rate Limiting', () => {
+  let MetricsServer: any;
+  let metricsServer: any;
+  
+  beforeEach(async () => {
+    // Clear mocks
+    jest.clearAllMocks();
+    
+    // Mock modules using jest.doMock
+    jest.doMock('../logger.js', () => ({ Logger: mockLogger }));
+    jest.doMock('../metrics_collector.js', () => ({ metricsCollector: mockMetricsCollector }));
+    jest.doMock('../config.js', () => ({ config: mockConfig }));
+    
+    // Import the module after mocking
+    const module = await import('../metrics_server.js');
+    MetricsServer = module.MetricsServer;
+  });
+
+  afterEach(async () => {
+    if (metricsServer && metricsServer.isRunning()) {
+      await metricsServer.stop();
+    }
+    jest.resetModules();
+  });
+
+  describe('Rate Limiting Configuration', () => {
+    it('should configure rate limit from environment variable', () => {
+      process.env.METRICS_RATE_LIMIT = '30';
+      metricsServer = new MetricsServer();
+      const config = metricsServer.getConfig();
+      expect(config.rateLimit).toBe(30);
+      delete process.env.METRICS_RATE_LIMIT;
+    });
+
+    it('should use default rate limit when not configured', () => {
+      delete process.env.METRICS_RATE_LIMIT;
+      metricsServer = new MetricsServer();
+      const config = metricsServer.getConfig();
+      expect(config.rateLimit).toBe(60);
+    });
+
+    it('should prioritize environment variable over constructor config', () => {
+      process.env.METRICS_RATE_LIMIT = '100';
+      metricsServer = new MetricsServer({ rateLimit: 50 });
+      const config = metricsServer.getConfig();
+      expect(config.rateLimit).toBe(100);
+      delete process.env.METRICS_RATE_LIMIT;
+    });
+  });
+
+  describe('Rate Limiting Logic', () => {
+    beforeEach(() => {
+      process.env.METRICS_ENABLED = 'true';
+      process.env.METRICS_RATE_LIMIT = '2'; // Low limit for testing
+      metricsServer = new MetricsServer({ enabled: true, port: 0 });
+    });
+
+    afterEach(() => {
+      delete process.env.METRICS_ENABLED;
+      delete process.env.METRICS_RATE_LIMIT;
+    });
+
+    it('should allow requests within the rate limit', () => {
+      // Test the rate limiting logic directly
+      const ip = '192.168.1.1';
+      
+      // First request should be allowed
+      const allowed1 = metricsServer['checkRateLimit'](ip);
+      expect(allowed1).toBe(true);
+      
+      // Second request should be allowed (within limit of 2)
+      const allowed2 = metricsServer['checkRateLimit'](ip);
+      expect(allowed2).toBe(true);
+    });
+
+    it('should block requests exceeding the rate limit', () => {
+      const ip = '192.168.1.2';
+      
+      // Use up the rate limit
+      metricsServer['checkRateLimit'](ip);
+      metricsServer['checkRateLimit'](ip);
+      
+      // Third request should be blocked
+      const blocked = metricsServer['checkRateLimit'](ip);
+      expect(blocked).toBe(false);
+    });
+
+    it('should handle different IPs separately', () => {
+      const ip1 = '192.168.1.3';
+      const ip2 = '192.168.1.4';
+      
+      // Use up rate limit for first IP
+      metricsServer['checkRateLimit'](ip1);
+      metricsServer['checkRateLimit'](ip1);
+      
+      // Third request from first IP should be blocked
+      expect(metricsServer['checkRateLimit'](ip1)).toBe(false);
+      
+      // But requests from second IP should still be allowed
+      expect(metricsServer['checkRateLimit'](ip2)).toBe(true);
+    });
+
+    it('should extract client IP from X-Forwarded-For header', () => {
+      const mockReq = {
+        headers: {
+          'x-forwarded-for': '203.0.113.1, 192.168.1.1, 10.0.0.1'
+        },
+        socket: { remoteAddress: '127.0.0.1' }
+      };
+      
+      const ip = metricsServer['getClientIP'](mockReq);
+      expect(ip).toBe('203.0.113.1');
+    });
+
+    it('should extract client IP from X-Real-IP header', () => {
+      const mockReq = {
+        headers: {
+          'x-real-ip': '203.0.113.2'
+        },
+        socket: { remoteAddress: '127.0.0.1' }
+      };
+      
+      const ip = metricsServer['getClientIP'](mockReq);
+      expect(ip).toBe('203.0.113.2');
+    });
+
+    it('should fall back to socket remote address', () => {
+      const mockReq = {
+        headers: {},
+        socket: { remoteAddress: '127.0.0.1' }
+      };
+      
+      const ip = metricsServer['getClientIP'](mockReq);
+      expect(ip).toBe('127.0.0.1');
+    });
+
+    it('should clean up expired rate limit entries', () => {
+      const ip = '192.168.1.5';
+      
+      // Add an entry
+      metricsServer['checkRateLimit'](ip);
+      expect(metricsServer['rateLimitMap'].has(ip)).toBe(true);
+      
+      // Simulate time passage by manually setting an expired reset time
+      const entry = metricsServer['rateLimitMap'].get(ip);
+      entry.resetTime = Date.now() - 1000; // 1 second ago
+      
+      // Cleanup should remove the expired entry
+      metricsServer['cleanupRateLimitMap'](Date.now());
+      expect(metricsServer['rateLimitMap'].has(ip)).toBe(false);
+    });
+  });
+});

--- a/src/utils/metrics_server.ts
+++ b/src/utils/metrics_server.ts
@@ -18,6 +18,15 @@ export interface MetricsServerConfig {
   port: number;
   host: string;
   enabled: boolean;
+  rateLimit?: number;
+}
+
+/**
+ * Rate limit tracking for IP addresses
+ */
+interface RateLimitEntry {
+  count: number;
+  resetTime: number;
 }
 
 /**
@@ -26,18 +35,21 @@ export interface MetricsServerConfig {
 export class MetricsServer {
   private server: http.Server | null = null;
   private config: MetricsServerConfig;
+  private rateLimitMap: Map<string, RateLimitEntry> = new Map();
 
   constructor(config?: Partial<MetricsServerConfig>) {
     this.config = {
       port: parseInt(process.env.METRICS_PORT || config?.port?.toString() || '9090', 10),
       host: process.env.METRICS_HOST || config?.host || '127.0.0.1',
       enabled: process.env.METRICS_ENABLED === 'true' || config?.enabled === true,
+      rateLimit: parseInt(process.env.METRICS_RATE_LIMIT || config?.rateLimit?.toString() || '60', 10),
     };
 
     Logger.debug('MetricsServer configured', {
       port: this.config.port,
       host: this.config.host,
       enabled: this.config.enabled,
+      rateLimit: this.config.rateLimit,
     });
   }
 
@@ -119,6 +131,53 @@ export class MetricsServer {
   }
 
   /**
+   * Check rate limit for IP address
+   */
+  private checkRateLimit(ip: string): boolean {
+    const now = Date.now();
+    const windowMs = 60 * 1000; // 1 minute window
+    
+    // Clean up expired entries
+    this.cleanupRateLimitMap(now);
+    
+    const entry = this.rateLimitMap.get(ip);
+    
+    if (!entry) {
+      // First request from this IP
+      this.rateLimitMap.set(ip, {
+        count: 1,
+        resetTime: now + windowMs,
+      });
+      return true;
+    }
+    
+    if (now > entry.resetTime) {
+      // Reset window
+      entry.count = 1;
+      entry.resetTime = now + windowMs;
+      return true;
+    }
+    
+    if (entry.count >= this.config.rateLimit!) {
+      return false; // Rate limit exceeded
+    }
+    
+    entry.count++;
+    return true;
+  }
+
+  /**
+   * Clean up expired rate limit entries to prevent memory leaks
+   */
+  private cleanupRateLimitMap(now: number): void {
+    for (const [ip, entry] of this.rateLimitMap.entries()) {
+      if (now > entry.resetTime) {
+        this.rateLimitMap.delete(ip);
+      }
+    }
+  }
+
+  /**
    * Handle HTTP requests
    */
   private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
@@ -156,7 +215,7 @@ export class MetricsServer {
       // Route requests
       switch (path) {
         case '/metrics':
-          this.handleMetricsRequest(res, format);
+          this.handleMetricsRequestWithRateLimit(req, res, format);
           break;
         case '/health':
           this.handleHealthRequest(res);
@@ -177,6 +236,69 @@ export class MetricsServer {
       Logger.error('Error handling metrics request', error);
       this.sendError(res, 500, 'Internal Server Error');
     }
+  }
+
+  /**
+   * Handle /metrics endpoint with rate limiting
+   */
+  private handleMetricsRequestWithRateLimit(req: http.IncomingMessage, res: http.ServerResponse, format: string): void {
+    // Extract client IP address
+    const clientIP = this.getClientIP(req);
+    
+    // Check rate limit
+    if (!this.checkRateLimit(clientIP)) {
+      const resetTime = this.getRateLimitResetTime(clientIP);
+      
+      Logger.warn(`Rate limit exceeded for IP ${clientIP} on /metrics endpoint`);
+      
+      // Set rate limit headers
+      res.setHeader('X-RateLimit-Limit', this.config.rateLimit!.toString());
+      res.setHeader('X-RateLimit-Remaining', '0');
+      res.setHeader('X-RateLimit-Reset', Math.ceil(resetTime / 1000).toString());
+      res.setHeader('Retry-After', Math.ceil((resetTime - Date.now()) / 1000).toString());
+      
+      this.sendError(res, 429, 'Too Many Requests');
+      return;
+    }
+    
+    // Add rate limit headers for successful requests
+    const entry = this.rateLimitMap.get(clientIP);
+    if (entry) {
+      res.setHeader('X-RateLimit-Limit', this.config.rateLimit!.toString());
+      res.setHeader('X-RateLimit-Remaining', Math.max(0, this.config.rateLimit! - entry.count).toString());
+      res.setHeader('X-RateLimit-Reset', Math.ceil(entry.resetTime / 1000).toString());
+    }
+    
+    this.handleMetricsRequest(res, format);
+  }
+
+  /**
+   * Get client IP address from request
+   */
+  private getClientIP(req: http.IncomingMessage): string {
+    // Check for forwarded headers first (for proxy/load balancer scenarios)
+    const forwarded = req.headers['x-forwarded-for'];
+    if (forwarded) {
+      // Take the first IP in the chain
+      const ips = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+      return ips.split(',')[0].trim();
+    }
+    
+    const realIP = req.headers['x-real-ip'];
+    if (realIP && !Array.isArray(realIP)) {
+      return realIP;
+    }
+    
+    // Fall back to socket remote address
+    return req.socket.remoteAddress || 'unknown';
+  }
+
+  /**
+   * Get rate limit reset time for IP
+   */
+  private getRateLimitResetTime(ip: string): number {
+    const entry = this.rateLimitMap.get(ip);
+    return entry ? entry.resetTime : Date.now() + 60000;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add IP-based rate limiting to /metrics endpoint
- Default limit: 60 requests/minute per IP (configurable via METRICS_RATE_LIMIT)
- HTTP 429 responses when limit exceeded
- Comprehensive unit tests for rate limiting logic

## Test plan

- [ ] Verify requests within limit are allowed
- [ ] Verify HTTP 429 response when limit exceeded
- [ ] Test METRICS_RATE_LIMIT environment variable configuration
- [ ] Verify rate limit headers are included in responses
- [ ] Test different IP addresses are tracked separately

Fixes #43

🤖 Generated with [Claude Code](https://claude.ai/code)