### PR TITLE
ci+deps: skip Claude review for bot PRs; bump MCP SDK to ^1.18 and zod to ^3.25

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Skip bot-authored PRs (dependabot, etc.) — they don't need AI code review
+    # and the action will fail with "non-human actor" if they trigger it.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
+
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "nlp:demo": "node examples/advanced_nlp_demo.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.16.0",
+    "@modelcontextprotocol/sdk": "^1.18.0",
     "compromise": "^14.12.0",
     "dotenv": "^16.4.5",
     "mathjs": "^14.3.0",
@@ -67,7 +67,7 @@
     "wink-lemmatizer": "^3.0.4",
     "wink-nlp": "^2.4.0",
     "wink-pos-tagger": "^2.2.2",
-    "zod": "^3.24.2"
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
## Summary

- **CI fix**: Add `if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'` guard to `claude-review` job — prevents the Anthropic action from failing with _"Workflow initiated by non-human actor"_ on all dependabot PRs (causing the 10 stale bot PRs piling up)
- **Dep bump**: `@modelcontextprotocol/sdk` `^1.16.0` → `^1.18.0` — picks up transport improvements and typed resource handling fixes from 1.17/1.18
- **Dep bump**: `zod` `^3.24.2` → `^3.25.0` — minor perf improvements, backwards compatible

## Motivation

All 10 open dependabot PRs in this repo have a failing `claude-review` check because the Anthropic action rejects bot actors. This fix prevents that from happening on future dependabot PRs.

## Test plan

- [ ] CI passes on this PR (verifies the workflow guard doesn't break human-authored review)
- [ ] Next dependabot PR does not fail `claude-review`
- [ ] TypeScript compilation succeeds with new MCP SDK version

🤖 Generated with [Claude Code](https://claude.com/claude-code)