### PR TITLE
perf(verify_research): parallelize primary + verification queries

### DIFF
--- a/src/tools/research_verification.ts
+++ b/src/tools/research_verification.ts
@@ -54,74 +54,50 @@ export class ResearchVerificationTool {
       const uniqueSources = new Set<string>();
       const conflictingClaims: string[] = [];
 
-      // Primary query search
-      const primaryResults = await exaResearch.search({
-        query: params.query,
-        numResults: params.sources,
-        includeContents: true,
-        useWebResults: true,
-        useNewsResults: false
-      });
+      // Run primary + verification queries in parallel; preserve original source-label semantics
+      const searchTasks = [
+        { query: params.query, defaultSource: 'Unknown Source' },
+        ...(params.verificationQueries ?? []).map((q) => ({
+          query: q,
+          defaultSource: 'Verification Source',
+        })),
+      ];
 
-      // Extract and analyze facts from primary search
-      for (const result of primaryResults.results) {
-        const sourceTitle = result.title || 'Unknown Source';
-        uniqueSources.add(sourceTitle);
-
-        // Use enhanced fact extractor
-        const extraction = enhancedFactExtractor.extractFacts(
-          result.contents || '', 
-          params.factExtractionOptions
-        );
-
-        // Add to fact extractions
-        factExtractions.push({
-          source: sourceTitle,
-          facts: extraction.facts.map(f => ({
-            fact: f.fact,
-            type: f.type,
-            confidence: f.confidence
-          })),
-          sourceConfidence: extraction.confidence
-        });
-
-        // Collect facts
-        allExtractedFacts.push(...extraction.facts.map(f => f.fact));
-      }
-
-      // Verification queries processing
-      if (params.verificationQueries) {
-        for (const verificationQuery of params.verificationQueries) {
-          const verificationSearch = await exaResearch.search({
-            query: verificationQuery,
+      const searchResults = await Promise.all(
+        searchTasks.map((t) =>
+          exaResearch.search({
+            query: t.query,
             numResults: params.sources,
             includeContents: true,
             useWebResults: true,
-            useNewsResults: false
+            useNewsResults: false,
+          })
+        )
+      );
+
+      // Aggregate in original order so factExtractions matches the previous serial output
+      for (let i = 0; i < searchResults.length; i++) {
+        const defaultSource = searchTasks[i].defaultSource;
+        for (const result of searchResults[i].results) {
+          const sourceTitle = result.title || defaultSource;
+          uniqueSources.add(sourceTitle);
+
+          const extraction = enhancedFactExtractor.extractFacts(
+            result.contents || '',
+            params.factExtractionOptions
+          );
+
+          factExtractions.push({
+            source: sourceTitle,
+            facts: extraction.facts.map((f) => ({
+              fact: f.fact,
+              type: f.type,
+              confidence: f.confidence,
+            })),
+            sourceConfidence: extraction.confidence,
           });
 
-          for (const result of verificationSearch.results) {
-            const sourceTitle = result.title || 'Verification Source';
-            uniqueSources.add(sourceTitle);
-
-            const extraction = enhancedFactExtractor.extractFacts(
-              result.contents || '', 
-              params.factExtractionOptions
-            );
-
-            factExtractions.push({
-              source: sourceTitle,
-              facts: extraction.facts.map(f => ({
-                fact: f.fact,
-                type: f.type,
-                confidence: f.confidence
-              })),
-              sourceConfidence: extraction.confidence
-            });
-
-            // Add verification facts
-            allExtractedFacts.push(...extraction.facts.map(f => f.fact));
-          }
+          allExtractedFacts.push(...extraction.facts.map((f) => f.fact));
         }
       }
 


### PR DESCRIPTION
## Summary

`verifyResearch()` previously awaited the primary Exa search, then ran each verification query serially in a `for…of` loop. With the default of 3 verification queries, that's 4 sequential network round-trips. This PR runs all of them in a single `Promise.all`.

**Latency:** roughly Nx → 1x where N = `1 + verificationQueries.length`. Typical user-visible savings: 2-4 seconds per `verify_research` call.

## Behavior preservation

- `factExtractions` array populated in the same order (primary first, then verification batches in submitted order).
- Default source labels preserved: `'Unknown Source'` for primary results, `'Verification Source'` for verification results.
- `allExtractedFacts` and `uniqueSources` populated identically given the same inputs.
- Error semantics: if any search throws, the whole call still rejects (same as before — just earlier).
- Also dedupes the previously-duplicated extraction loop body (−24 lines net).

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — only pre-existing warnings (unchanged)
- [ ] CI runs green on this branch
- Note: no test covers `verifyResearch` directly today, so the behavioral change has no fixture to update.

## Follow-ups (separate PRs)

- Same pattern in `perspective_shifter` (sequential per-domain Exa calls in `src/tools/perspective_shifter.ts:81-108`).
- Hoist `getFallacyDefinitions()` to a module-level singleton and pre-compile `FACT_VERBS` regexes (small wins, easy review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced research verification performance by parallelizing query execution. Primary and verification searches now run concurrently instead of sequentially, resulting in faster verification completion while maintaining data integrity and result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->