### PR TITLE
perf(perspective_shifter): parallelize per-domain Exa searches

### DIFF
--- a/src/tools/perspective_shifter.ts
+++ b/src/tools/perspective_shifter.ts
@@ -76,21 +76,23 @@ async function generatePerspectives(
       domains.push(`custom_domain_${domains.length + 1}`);
     }
 
-    const perspectives: string[] = [];
+    const selectedDomains = domains.slice(0, numberOfPerspectives);
 
-    for (const domain of domains.slice(0, numberOfPerspectives)) {
-      const researchQuery = `Analyze the problem "${problem}" from the perspective of a ${domain}`;
+    // Run one Exa search per domain in parallel
+    const searchResults = await Promise.all(
+      selectedDomains.map((domain) =>
+        exaResearch.search({
+          query: `Analyze the problem "${problem}" from the perspective of a ${domain}`,
+          numResults: 2,
+          useWebResults: true,
+          useNewsResults: false,
+          includeContents: true,
+        })
+      )
+    );
 
-      // Use Exa research to get diverse perspectives
-      const searchResults = await exaResearch.search({
-        query: researchQuery,
-        numResults: 2,
-        useWebResults: true,
-        useNewsResults: false,
-        includeContents: true,
-      });
-
-      const perspectiveInsights = exaResearch.extractKeyFacts(searchResults.results);
+    const perspectives = selectedDomains.map((domain, i) => {
+      const perspectiveInsights = exaResearch.extractKeyFacts(searchResults[i].results);
 
       const perspectiveSection: string[] = [
         `### ${domain.toUpperCase()} Perspective\n\n`,
@@ -104,8 +106,8 @@ async function generatePerspectives(
         );
       }
 
-      perspectives.push(perspectiveSection.join(''));
-    }
+      return perspectiveSection.join('');
+    });
 
     result += perspectives.join('\n\n');
 


### PR DESCRIPTION
## Summary

`generatePerspectives()` ran one Exa search per domain in a serial `for…of` loop. With the default of 3 perspectives that's 3 sequential network round-trips. This PR runs them in a single `Promise.all`.

**Latency:** roughly Nx → 1x where N = `numberOfPerspectives`. Typical user-visible savings: 1-3 seconds per `perspective_shifter` call.

## Behavior preservation

- Same domain selection: `domains.slice(0, numberOfPerspectives)`.
- Same query string and Exa search options per domain.
- Output template unchanged (per-domain section header, insights, optional actionable bullet, joined with `\n\n`).
- Order of perspectives in output matches input domain order.

## Test plan

- [x] `npm run typecheck` — passes
- [x] Existing integration tests in `logical_reasoning_tools.test.ts` and `market_analysis_workflow.test.ts` only check substring presence (no ordering or count assertions affected).
- [ ] CI runs green on this branch

## Follow-ups (separate PRs)

- Hoist `getFallacyDefinitions()` to a module-level singleton in `logical_fallacy_detector.ts`.
- Pre-compile `FACT_VERBS` regexes in `advanced_fact_extraction.ts:containsFactVerb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)